### PR TITLE
Add Magento 2.3.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7",
-        "magento/framework": "^100|^101",
+        "magento/framework": "^100|^101|^102",
         "snowio/magento2-lock": "^1"
     },
     "autoload": {


### PR DESCRIPTION
### Description
This PR updates the composer version constraints to support Magento 2.3.1. No additional modifications were needed

**NB**: This is dependant on https://github.com/snowio/magento2-lock/pull/7