### PR TITLE
Amend constructor arg to use concrete class not interface

### DIFF
--- a/Model/ResourceModificationTimeRepository.php
+++ b/Model/ResourceModificationTimeRepository.php
@@ -8,7 +8,12 @@ class ResourceModificationTimeRepository
 {
     private \Magento\Framework\DB\Adapter\AdapterInterface $dbConnection;
 
-    public function __construct(\Magento\Framework\ObjectManager\ContextInterface $dbContext, $connectionName = null)
+    /**
+     * ResourceModificationTimeRepository constructor.
+     * @param Context $dbContext
+     * @param null $connectionName
+     */
+    public function __construct(Context $dbContext, $connectionName = null)
     {
         $this->dbConnection = $dbContext->getResources()->getConnection($connectionName);
     }


### PR DESCRIPTION
### Description

Amend constructor arg to use concrete class not interface. Resolves:

```bash
Cannot instantiate interface Magento\Framework\ObjectManager\ContextInterface
```